### PR TITLE
fix deserialize of int types

### DIFF
--- a/lib/src/JSONDeserializer.bf
+++ b/lib/src/JSONDeserializer.bf
@@ -60,12 +60,14 @@ namespace JSON_Beef
 			}
 
 			let jsonObj = res.Value;
-			if (!AreTypeMatching(jsonObj, obj))
+			/*if (!AreTypeMatching(jsonObj, obj))
 			{
 				return .Err(.TYPE_NOT_MATCHING);
-			}
+			}*/
 
 			let finalRes = DeserializeObjectInternal(jsonObj, obj);
+
+			delete res.Value;
 
 			switch (finalRes)
 			{
@@ -268,9 +270,80 @@ namespace JSON_Beef
 			{
 				switch (fieldType)
 				{
-				case typeof(String), typeof(int), typeof(float):
+				case typeof(String):
 					let res = jsonObj.Get(fieldName, fieldType);
 
+					switch (res)
+					{
+					case .Err(let err):
+						return .Err(.ERROR_PARSING);
+					case .Ok(let val):
+						if (val != null) // Todo: For now FieldInfo.SetValue crash when the val is null we will remove this if after SetValue bug get fixed.
+							valueSet = field.SetValue(obj, val);
+					}
+				case typeof(int):
+					let res = jsonObj.Get<int>(fieldName);
+
+					switch (res)
+					{
+					case .Err(let err):
+						return .Err(.ERROR_PARSING);
+					case .Ok(let val):
+						valueSet = field.SetValue(obj, val);
+					}
+				case typeof(uint):
+					let res = jsonObj.Get<uint>(fieldName);
+					
+					switch (res)
+					{
+					case .Err(let err):
+						return .Err(.ERROR_PARSING);
+					case .Ok(let val):
+						valueSet = field.SetValue(obj, val);
+					}
+				case typeof(int32):
+					let res = jsonObj.Get<int32>(fieldName);
+					
+					switch (res)
+					{
+					case .Err(let err):
+						return .Err(.ERROR_PARSING);
+					case .Ok(let val):
+						valueSet = field.SetValue(obj, val);
+					}
+				case typeof(uint32):
+					let res = jsonObj.Get<uint32>(fieldName);
+					
+					switch (res)
+					{
+					case .Err(let err):
+						return .Err(.ERROR_PARSING);
+					case .Ok(let val):
+						valueSet = field.SetValue(obj, val);
+					}
+				case typeof(int64):
+					let res = jsonObj.Get<int64>(fieldName);
+					
+					switch (res)
+					{
+					case .Err(let err):
+						return .Err(.ERROR_PARSING);
+					case .Ok(let val):
+						valueSet = field.SetValue(obj, val);
+					}
+				case typeof(uint64):
+					let res = jsonObj.Get<uint64>(fieldName);
+					
+					switch (res)
+					{
+					case .Err(let err):
+						return .Err(.ERROR_PARSING);
+					case .Ok(let val):
+						valueSet = field.SetValue(obj, val);
+					}
+				case typeof(float):
+					let res = jsonObj.Get<float>(fieldName);
+					
 					switch (res)
 					{
 					case .Err(let err):

--- a/lib/src/JSONDeserializer.bf
+++ b/lib/src/JSONDeserializer.bf
@@ -279,7 +279,7 @@ namespace JSON_Beef
 						return .Err(.ERROR_PARSING);
 					case .Ok(let val):
 						if (val != null) // Todo: For now FieldInfo.SetValue crash when the val is null we will remove this if after SetValue bug get fixed.
-							valueSet = field.SetValue(obj, val);
+							valueSet = field.SetValue(obj, new String((String)val));
 					}
 				case typeof(int):
 					let res = jsonObj.Get<int>(fieldName);

--- a/lib/src/JSONObject.bf
+++ b/lib/src/JSONObject.bf
@@ -62,7 +62,7 @@ namespace JSON_Beef
 			{
 				let value = dictionary[key];
 
-				if (value.VariantType == typeof(T))
+				if (value.VariantType == typeof(T) || (value.VariantType.IsInteger && typeof(T).IsInteger))
 				{
 					T ret = value.Get<T>();
 					return .Ok(ret);
@@ -84,6 +84,10 @@ namespace JSON_Beef
 				{
 					let ret = value.Get<Object>();
 					return .Ok(ret);
+				}
+				else if (value.VariantType == typeof(JSON_LITERAL))
+				{
+					return .Ok(null);
 				}
 
 				return .Err(.INVALID_TYPE);

--- a/lib/src/JSONObject.bf
+++ b/lib/src/JSONObject.bf
@@ -85,7 +85,7 @@ namespace JSON_Beef
 					let ret = value.Get<Object>();
 					return .Ok(ret);
 				}
-				else if (value.VariantType == typeof(JSON_LITERAL))
+				else if (value.VariantType == typeof(JSON_LITERAL) && value.Get<JSON_LITERAL>() == .NULL)
 				{
 					return .Ok(null);
 				}


### PR DESCRIPTION
Remove the type matching object and fix one memory leak

Add support for different int types

I also add support for null objects and beefy fixed a bug for setting nulls.
https://github.com/beefytech/Beef/issues/376

I removed the type matching because maybe you don't need every filed in a JSON object or vice versa